### PR TITLE
Support configuration via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Highlights include:
 
 Install using [uv](https://docs.astral.sh/uv/). This package conforms the concept of a [tool](https://docs.astral.sh/uv/concepts/tools/) and hence can simply install / run with `uvx`:
 
-    uvx mockstack
+    uvx mockstack --help
 
 or install into a persistent environment and add it to the PATH with:
 
@@ -32,14 +32,19 @@ or install into a persistent environment and add it to the PATH with:
 
 ## Usage
 
-Available configuration options are [here](https://github.com/adamhadani/mockstack/blob/main/mockstack/config.py). Setting individual options can be done with env. variables as in the following example:
+Available configuration options are [here](https://github.com/adamhadani/mockstack/blob/main/mockstack/config.py).
+
+Setting individual options can be done either through an `.env` file, individual environment variables, or command-line arguments. For example:
 
 ```shell
+    export MOCKSTACK__STRATEGY=filefixtures
     export MOCKSTACK__TEMPLATES_DIR=~/mockstack-templates/
     export MOCKSTACK__OPENTELEMETRY__ENABLED=true
     export MOCKSTACK__OPENTELEMETRY__CAPTURE_RESPONSE_BODY=true
-    uv run
+    uvx mockstack
 ```
+
+See also the included [.env.example](https://github.com/adamhadani/mockstack/blob/main/.env.example) for more examples. You can copy that file to `.env` and fill in configuration as needed based on the given examples.
 
 Out of the box, you get the following behavior when using the default `filefixtures` strategy:
 
@@ -73,8 +78,6 @@ If you are contributing to development, you will want to clone this project, and
     uv sync
     uv pip install -e .
 
-Copy the included [.env.example](https://github.com/adamhadani/mockstack/blob/main/.env.example) file to `.env` and fill in configuration as needed based on the given examples.
-
 Run in development mode (for live-reload of changes when developing):
 
-    uv run uvicorn --factory mockstack.main:create_app --reload
+    uv run -- mockstack --debug

--- a/mockstack/config.py
+++ b/mockstack/config.py
@@ -9,7 +9,12 @@ from pydantic_settings import (
     SettingsConfigDict,
 )
 
-from mockstack.constants import ProxyRulesRedirectVia
+from mockstack.constants import (
+    ENV_FILE,
+    ENV_NESTED_DELIMITER,
+    ENV_PREFIX,
+    ProxyRulesRedirectVia,
+)
 
 
 class OpenTelemetrySettings(BaseSettings):
@@ -33,9 +38,9 @@ class Settings(BaseSettings):
     """
 
     model_config = SettingsConfigDict(
-        env_prefix="mockstack__",
-        env_file=".env",
-        env_nested_delimiter="__",
+        env_prefix=ENV_PREFIX,
+        env_file=ENV_FILE,
+        env_nested_delimiter=ENV_NESTED_DELIMITER,
     )
 
     # whether to run in debug mode
@@ -149,13 +154,17 @@ class Settings(BaseSettings):
         return self
 
 
-class SettingsForCli(Settings):
+# Nb. We separate the Cli-specific parameters since currently breaks pytest
+# when running via pre-commit hooks. Can remove once fixed by pytest / pre-commit.
+
+
+class CliSettings(Settings):
     """Settings for mockstack CLI."""
 
     model_config = SettingsConfigDict(
-        env_prefix="mockstack__",
-        env_file=".env",
-        env_nested_delimiter="__",
+        env_prefix=ENV_PREFIX,
+        env_file=ENV_FILE,
+        env_nested_delimiter=ENV_NESTED_DELIMITER,
         cli_parse_args=True,
         cli_kebab_case=True,
         cli_hide_none_type=True,

--- a/mockstack/config.py
+++ b/mockstack/config.py
@@ -104,7 +104,7 @@ class Settings(BaseSettings):
         "handlers": {
             "console": {
                 "class": "logging.StreamHandler",
-                "level": "DEBUG",
+                "level": "INFO",
                 "formatter": "standard",
                 "stream": "ext://sys.stdout",
             },
@@ -112,23 +112,23 @@ class Settings(BaseSettings):
         "loggers": {
             "uvicorn": {
                 "handlers": ["console"],
-                "level": "INFO",
+                "level": "DEBUG",
                 "propagate": False,
             },
             "FileFixturesStrategy": {
                 "handlers": ["console"],
-                "level": "INFO",
+                "level": "DEBUG",
                 "propagate": False,
             },
             "ProxyRulesStrategy": {
                 "handlers": ["console"],
-                "level": "INFO",
+                "level": "DEBUG",
                 "propagate": False,
             },
         },
         "root": {
             "handlers": ["console"],
-            "level": "INFO",
+            "level": "DEBUG",
             "propagate": False,
         },
     }

--- a/mockstack/config.py
+++ b/mockstack/config.py
@@ -2,7 +2,12 @@ from functools import lru_cache
 from typing import Any, Literal, Self
 
 from pydantic import DirectoryPath, FilePath, model_validator
-from pydantic_settings import BaseSettings, CliSuppress, SettingsConfigDict
+from pydantic_settings import (
+    BaseSettings,
+    CliImplicitFlag,
+    CliSuppress,
+    SettingsConfigDict,
+)
 
 from mockstack.constants import ProxyRulesRedirectVia
 
@@ -19,13 +24,7 @@ class OpenTelemetrySettings(BaseSettings):
     capture_response_body: bool = False
 
 
-class Settings(
-    BaseSettings,
-    # cli_parse_args=True,  # type: ignore[call-arg]
-    cli_kebab_case=True,  # type: ignore[call-arg]
-    cli_hide_none_type=True,  # type: ignore[call-arg]
-    cli_avoid_json=True,  # type: ignore[call-arg]
-):
+class Settings(BaseSettings):
     """Settings for mockstack.
 
     Default values are defined below and can be overwritten using an .env file
@@ -40,7 +39,7 @@ class Settings(
     )
 
     # whether to run in debug mode
-    debug: bool = False
+    debug: CliImplicitFlag[bool] = False
 
     # host to run the server on
     host: str = "0.0.0.0"
@@ -66,7 +65,7 @@ class Settings(
 
     # controls behavior of proxying. Whether to simulate creation of resources
     # when a POST request is made to a resource that doesn't match any rules..
-    proxyrules_simulate_create_on_missing: bool = False
+    proxyrules_simulate_create_on_missing: CliImplicitFlag[bool] = False
 
     # metadata fields to inject into created resources.
     # A few template fields are available. See documentation for more details.
@@ -148,6 +147,20 @@ class Settings(
                 )
 
         return self
+
+
+class SettingsForCli(Settings):
+    """Settings for mockstack CLI."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="mockstack__",
+        env_file=".env",
+        env_nested_delimiter="__",
+        cli_parse_args=True,
+        cli_kebab_case=True,
+        cli_hide_none_type=True,
+        cli_avoid_json=True,
+    )
 
 
 @lru_cache

--- a/mockstack/constants.py
+++ b/mockstack/constants.py
@@ -2,7 +2,10 @@
 
 from enum import StrEnum
 
-# proxyrules strategy constants
+
+ENV_PREFIX = "mockstack__"
+ENV_FILE = ".env"
+ENV_NESTED_DELIMITER = "__"
 
 
 class ProxyRulesRedirectVia(StrEnum):

--- a/mockstack/display.py
+++ b/mockstack/display.py
@@ -27,7 +27,8 @@ def announce(app: FastAPI, settings: Settings):
     logger = logging.getLogger("uvicorn")
     logger.info(
         f"{HIGHLIGHT}mockstack{ENDC} ready to roll. "
-        f"Using strategy: {HIGHLIGHT}{settings.strategy}{ENDC}, "
+        f"debug: {HIGHLIGHT}{settings.debug}{ENDC}. "
+        f"strategy: {HIGHLIGHT}{settings.strategy}{ENDC}. "
     )
     logger.info(str(app.state.strategy))
     logger.info(

--- a/mockstack/lifespan.py
+++ b/mockstack/lifespan.py
@@ -1,7 +1,7 @@
 """FastAPI application lifecycle management."""
 
 from contextlib import asynccontextmanager
-from logging import config
+from logging import DEBUG, config
 from typing import Callable
 
 from fastapi import FastAPI
@@ -21,7 +21,12 @@ def lifespan_provider(
 
         This is the context manager that FastAPI will use to manage the lifecycle of the application.
         """
+        if settings.debug:
+            # Enable verbose debug logging if debug mode is set.
+            settings.logging["handlers"]["console"]["level"] = DEBUG
+
         config.dictConfig(settings.logging)
+
         announce(app, settings)
 
         yield

--- a/mockstack/main.py
+++ b/mockstack/main.py
@@ -13,7 +13,7 @@ from mockstack.telemetry import opentelemetry_provider
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
-    """Create the FastAPI app."""
+    """Create the fastapi app and bootstrap all dependencies."""
     settings = settings or settings_provider()
 
     app = FastAPI(lifespan=lifespan_provider(settings))
@@ -39,7 +39,7 @@ def run():
 
     app = create_app(settings=settings)
 
-    uvicorn.run(app, host=settings.host, port=settings.port, reload=settings.debug)
+    uvicorn.run(app, host=settings.host, port=settings.port)
 
 
 def version():

--- a/mockstack/main.py
+++ b/mockstack/main.py
@@ -3,7 +3,7 @@
 from fastapi import FastAPI
 from pydantic_settings import CliApp, CliSettingsSource
 
-from mockstack.config import Settings, settings_provider
+from mockstack.config import Settings, SettingsForCli, settings_provider
 from mockstack.lifespan import lifespan_provider
 from mockstack.middleware import middleware_provider
 from mockstack.routers.catchall import catchall_router_provider
@@ -34,8 +34,8 @@ def run():
     import uvicorn
 
     parser = argparse.ArgumentParser()
-    cli_settings = CliSettingsSource(Settings, root_parser=parser)
-    settings = CliApp.run(Settings, cli_settings_source=cli_settings)
+    cli_settings = CliSettingsSource(SettingsForCli, root_parser=parser)
+    settings = CliApp.run(SettingsForCli, cli_settings_source=cli_settings)
 
     app = create_app(settings=settings)
 

--- a/mockstack/main.py
+++ b/mockstack/main.py
@@ -3,7 +3,7 @@
 from fastapi import FastAPI
 from pydantic_settings import CliApp, CliSettingsSource
 
-from mockstack.config import Settings, SettingsForCli, settings_provider
+from mockstack.config import CliSettings, Settings, settings_provider
 from mockstack.lifespan import lifespan_provider
 from mockstack.middleware import middleware_provider
 from mockstack.routers.catchall import catchall_router_provider
@@ -34,8 +34,8 @@ def run():
     import uvicorn
 
     parser = argparse.ArgumentParser()
-    cli_settings = CliSettingsSource(SettingsForCli, root_parser=parser)
-    settings = CliApp.run(SettingsForCli, cli_settings_source=cli_settings)
+    cli_settings = CliSettingsSource(CliSettings, root_parser=parser)
+    settings = CliApp.run(CliSettings, cli_settings_source=cli_settings)
 
     app = create_app(settings=settings)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Homepage = "https://github.com/adamhadani/mockstack"
 Issues = "https://github.com/adamhadani/mockstack/issues"
 
 [project.scripts]
-mockstack = "mockstack.main:cli"
+mockstack = "mockstack.main:run"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
closes #16 

- **refactor cli for supporting pydantic-settings integration so can override config via cli**
- **config refactoring contd**
- **fix pytest-precommit regression on using Cli stuff with settings**
