### PR TITLE
refactor opentelemetry integration to be applied as a middleware

### DIFF
--- a/mockstack/middleware.py
+++ b/mockstack/middleware.py
@@ -2,9 +2,12 @@
 
 import time
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
+from opentelemetry import trace
+from opentelemetry.propagate import extract
 
 from mockstack.config import Settings
+from mockstack.telemetry import extract_body, span_name_for
 
 
 def middleware_provider(app: FastAPI, settings: Settings) -> None:
@@ -17,3 +20,36 @@ def middleware_provider(app: FastAPI, settings: Settings) -> None:
         process_time = time.time() - start_time
         response.headers["X-Process-Time"] = str(process_time)
         return response
+
+    @app.middleware("http")
+    async def instrument_opentelemetry(request: Request, call_next):
+        tracer = trace.get_tracer(__name__)
+        ctx = extract(request.headers)
+        with tracer.start_as_current_span(span_name_for(request), context=ctx) as span:
+            span.set_attribute("http.method", request.method)
+            span.set_attribute("http.url", str(request.url))
+
+            response = await call_next(request)
+
+            span.set_attribute("http.status_code", response.status_code)
+
+            # Nb. persisting response body can hamper performance,
+            # expose sensitive / PII data, and / or may not be needed.
+            # it is therefore an opt-in setting.
+            if settings.opentelemetry.capture_response_body:
+                body = await extract_body(response)
+
+                # for semantics of payload collection see:
+                # https://github.com/open-telemetry/oteps/pull/234
+                span.set_attribute("http.response.body", body)
+
+                # recreate response with the same body since when consuming it to log it above
+                # we effectively "deplete" the iterator.
+                response = Response(
+                    content=body,
+                    status_code=response.status_code,
+                    headers=dict(response.headers),
+                    media_type=response.media_type,
+                )
+
+            return response

--- a/mockstack/routers/catchall.py
+++ b/mockstack/routers/catchall.py
@@ -1,11 +1,8 @@
 """Routes for the mockstack app."""
 
 from fastapi import FastAPI, Request
-from opentelemetry import trace
-from opentelemetry.propagate import extract
 
 from mockstack.config import Settings
-from mockstack.telemetry import span_name_for
 
 
 def catchall_router_provider(app: FastAPI, settings: Settings) -> None:
@@ -14,20 +11,4 @@ def catchall_router_provider(app: FastAPI, settings: Settings) -> None:
     @app.route("/{full_path:path}", methods=["GET", "PATCH", "POST", "PUT", "DELETE"])
     async def catch_all(request: Request):
         """Catch all requests and delegate to the strategy."""
-        tracer = trace.get_tracer(__name__)
-        ctx = extract(request.headers)
-        with tracer.start_as_current_span(span_name_for(request), context=ctx) as span:
-            span.set_attribute("http.method", request.method)
-            span.set_attribute("http.url", str(request.url))
-
-            response = await app.state.strategy.apply(request)
-
-            span.set_attribute("http.status_code", response.status_code)
-
-            # Nb. persisting response body can hamper performance,
-            # expose sensitive / PII data, and / or may not be needed.
-            # it is therefore an opt-in setting.
-            if settings.opentelemetry.capture_response_body:
-                span.set_attribute("response", response.body)
-
-            return response
+        return await app.state.strategy.apply(request)

--- a/mockstack/telemetry.py
+++ b/mockstack/telemetry.py
@@ -2,7 +2,7 @@
 
 from importlib import metadata
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import Resource
@@ -15,6 +15,21 @@ from mockstack.config import Settings
 def span_name_for(request: Request) -> str:
     """Get the span name for a request."""
     return f"{request.method.upper()} {request.url.path}"
+
+
+async def extract_body(response: Response) -> str:
+    """Extract the body of a response."""
+
+    async def read_response_body(response: Response) -> bytes:
+        """Helper function to read response body asynchronously into memory."""
+        body = b""
+        async for chunk in response.body_iterator:
+            body += chunk
+        return body
+
+    body = await read_response_body(response)
+
+    return body.decode()
 
 
 def opentelemetry_provider(app: FastAPI, settings: Settings) -> None:


### PR DESCRIPTION
closes #32 
- Extract OpenTelemetry instrumentation to middleware.
- add functionality to properly materialize response body if flag is set to report it as well while making sure it is available for real response as well.