### PR TITLE
add integration of opentelemetry instrumentation and strategies to support adding custom attributes which are strategy-specific

### DIFF
--- a/mockstack/middleware.py
+++ b/mockstack/middleware.py
@@ -36,6 +36,11 @@ def middleware_provider(app: FastAPI, settings: Settings) -> None:
                 request, span, sensitive_headers=SENSITIVE_HEADERS
             )
 
+            # Make the current opentelemetry span available to the request.
+            # This is useful for strategies that need to add custom attributes
+            # to the span associated with the request.
+            request.state.span = span
+
             response = await call_next(request)
 
             span = with_response_attributes(

--- a/mockstack/strategies/base.py
+++ b/mockstack/strategies/base.py
@@ -17,3 +17,12 @@ class BaseStrategy(ABC):
     async def apply(self, request: Request) -> Response:
         """Apply the strategy to the request and response."""
         pass
+
+    def update_opentelemetry(self, request: Request, *args, **kwargs) -> None:
+        """Update the opentelemetry span with strategy-specific attributes.
+
+        A span is made available on `request.state.span` to use.
+        When OpenTelemetry is not enabled, this span will exist but will not be reported.
+
+        """
+        pass

--- a/mockstack/strategies/filefixtures.py
+++ b/mockstack/strategies/filefixtures.py
@@ -158,4 +158,3 @@ class FileFixturesStrategy(BaseStrategy, CreateMixin):
         span.set_attribute(
             "mockstack.filefixtures.template_name", template_args["name"]
         )
-        span.set_attribute("mockstack.filefixtures.template_args", template_args)

--- a/mockstack/strategies/filefixtures.py
+++ b/mockstack/strategies/filefixtures.py
@@ -129,6 +129,7 @@ class FileFixturesStrategy(BaseStrategy, CreateMixin):
                 continue
 
             self.logger.debug("Found template filename: %s", filename)
+            self.update_opentelemetry(request, template_args)
             template = self.env.get_template(template_args["name"])
 
             return Response(
@@ -149,3 +150,12 @@ class FileFixturesStrategy(BaseStrategy, CreateMixin):
             status_code=status.HTTP_404_NOT_FOUND,
         )
         """
+
+    def update_opentelemetry(self, request: Request, template_args: dict) -> None:
+        """Update the opentelemetry span with the file fixtures details."""
+        span = request.state.span
+
+        span.set_attribute(
+            "mockstack.filefixtures.template_name", template_args["name"]
+        )
+        span.set_attribute("mockstack.filefixtures.template_args", template_args)

--- a/mockstack/tests/conftest.py
+++ b/mockstack/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared fixtures for the unit-tests."""
 
 import os
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import FastAPI
@@ -11,10 +12,19 @@ from mockstack.strategies.filefixtures import FileFixturesStrategy
 
 
 @pytest.fixture
-def app(settings):
+def span():
+    """Create a mock span object for testing."""
+    span = MagicMock()
+    span.set_attribute = MagicMock()
+    return span
+
+
+@pytest.fixture
+def app(settings, span):
     """Create a FastAPI app for testing."""
     app = FastAPI()
     app.state.strategy = FileFixturesStrategy(settings)
+    app.state.span = span
     return app
 
 

--- a/mockstack/tests/strategies/test_filefixtures.py
+++ b/mockstack/tests/strategies/test_filefixtures.py
@@ -18,7 +18,7 @@ def test_filefixtures_strategy_init(settings):
 
 
 @pytest.mark.asyncio
-async def test_filefixtures_strategy_apply(settings):
+async def test_filefixtures_strategy_apply(settings, span):
     """Test the FileFixturesStrategy apply method."""
     strategy = FileFixturesStrategy(settings)
     request = Request(
@@ -30,6 +30,7 @@ async def test_filefixtures_strategy_apply(settings):
             "headers": [],
         }
     )
+    request.state.span = span
 
     with pytest.raises(HTTPException) as exc_info:
         await strategy.apply(request)
@@ -38,7 +39,7 @@ async def test_filefixtures_strategy_apply(settings):
 
 
 @pytest.mark.asyncio
-async def test_file_fixtures_strategy_apply_success(settings):
+async def test_file_fixtures_strategy_apply_success(settings, span):
     """Test the FileFixturesStrategy apply method when template exists."""
     # Setup
     strategy = FileFixturesStrategy(settings)
@@ -61,6 +62,7 @@ async def test_file_fixtures_strategy_apply_success(settings):
                 "headers": [],
             }
         )
+        request.state.span = span
 
         # Execute
         response = await strategy.apply(request)
@@ -72,7 +74,7 @@ async def test_file_fixtures_strategy_apply_success(settings):
 
 
 @pytest.mark.asyncio
-async def test_file_fixtures_strategy_apply_template_not_found(settings):
+async def test_file_fixtures_strategy_apply_template_not_found(settings, span):
     """Test the FileFixturesStrategy apply method when template doesn't exist."""
     # Setup
     strategy = FileFixturesStrategy(settings)
@@ -88,6 +90,7 @@ async def test_file_fixtures_strategy_apply_template_not_found(settings):
                 "headers": [],
             }
         )
+        request.state.span = span
 
         # Execute and Assert
         with pytest.raises(HTTPException) as exc_info:

--- a/mockstack/tests/strategies/test_proxyrules.py
+++ b/mockstack/tests/strategies/test_proxyrules.py
@@ -124,7 +124,7 @@ def test_proxy_rules_strategy_load_rules(settings):
     assert all(isinstance(rule, Rule) for rule in rules)
 
 
-def test_proxy_rules_strategy_rule_for(settings):
+def test_proxy_rules_strategy_rule_for(settings, span):
     """Test finding a matching rule for a request."""
     strategy = ProxyRulesStrategy(settings)
     request = Request(
@@ -136,12 +136,13 @@ def test_proxy_rules_strategy_rule_for(settings):
             "headers": [],
         }
     )
+    request.state.span = span
     rule = strategy.rule_for(request)
     assert rule is not None
     assert isinstance(rule, Rule)
 
 
-def test_proxy_rules_strategy_rule_for_no_match(settings):
+def test_proxy_rules_strategy_rule_for_no_match(settings, span):
     """Test when no rule matches a request."""
     strategy = ProxyRulesStrategy(settings)
     request = Request(
@@ -153,12 +154,13 @@ def test_proxy_rules_strategy_rule_for_no_match(settings):
             "headers": [],
         }
     )
+    request.state.span = span
     rule = strategy.rule_for(request)
     assert rule is None
 
 
 @pytest.mark.asyncio
-async def test_proxy_rules_strategy_apply(settings):
+async def test_proxy_rules_strategy_apply(settings, span):
     """Test applying a rule to a request."""
     strategy = ProxyRulesStrategy(settings)
     request = Request(
@@ -170,13 +172,14 @@ async def test_proxy_rules_strategy_apply(settings):
             "headers": [],
         }
     )
+    request.state.span = span
     response = await strategy.apply(request)
     assert isinstance(response, RedirectResponse)
     assert response.headers["location"] == "/projects/123"
 
 
 @pytest.mark.asyncio
-async def test_proxy_rules_strategy_apply_no_match(settings):
+async def test_proxy_rules_strategy_apply_no_match(settings, span):
     """Test applying strategy when no rule matches."""
     strategy = ProxyRulesStrategy(settings)
     request = Request(
@@ -188,13 +191,14 @@ async def test_proxy_rules_strategy_apply_no_match(settings):
             "headers": [],
         }
     )
+    request.state.span = span
     response = await strategy.apply(request)
     assert response.status_code == 404
 
 
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="TODO: Fix this test")
-async def test_proxy_rules_strategy_apply_reverse_proxy(settings_reverse_proxy):
+async def test_proxy_rules_strategy_apply_reverse_proxy(settings_reverse_proxy, span):
     """Test applying a rule to a request with reverse proxy enabled."""
     # Mock the httpx.AsyncClient to avoid making real HTTP requests
     mock_response = MagicMock()  # Use MagicMock for response to avoid async attributes
@@ -218,6 +222,7 @@ async def test_proxy_rules_strategy_apply_reverse_proxy(settings_reverse_proxy):
                 "headers": [("host", "example.com")],
             }
         )
+        request.state.span = span
         response = await strategy.apply(request)
 
         # Verify the response


### PR DESCRIPTION
closes #36 
- Add OpenTelemetry instrumentation support to individual strategies to be able to report custom attributes to the tracer
- Add strategy-specific attributes to filefixtures and proxyrules strategies to report useful metrics under the `mockstack.*` namesapce.
- Update unit-tests to support this
