### PR TITLE
filefixtures template support for POSTs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ MOCKSTACK__STRATEGY = filefixtures
 # and other hybrid strategies utilizing templates.
 MOCKSTACK__TEMPLATES_DIR = "/some/path/templates/"
 
+# When using filefixtures strategy, controls whether to enable
+# using templates for POST requests or go directly to simulate a create.
+FILEFIXTURES_ENABLE_TEMPLATES_FOR_POST = false
+
 # rules table for the proxyrules strategy.
 # see .mockstack/tests/fixtures/ for examples.
 MOCKSTACK__PROXYRULES_RULES_FILENAME="/some/path/proxyrules.yml"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ All configuration options are prefixed with `MOCKSTACK__` when using environment
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `templates_dir` | string | - | Base directory for templates used by the strategy |
+| `filefixtures_enable_templates_for_post` | boolean | `false` | Whether to enable template-based responses for POST requests |
 
 ### ProxyRules Strategy
 

--- a/docs/strategies/filefixtures.md
+++ b/docs/strategies/filefixtures.md
@@ -71,7 +71,8 @@ The strategy requires the following configuration:
 ```python
 settings = Settings(
     strategy="filefixtures",
-    templates_dir="/path/to/templates"
+    templates_dir="/path/to/templates",
+    filefixtures_enable_templates_for_post=True  # Optional: Enables template-based responses for POST requests
 )
 ```
 

--- a/examples/filefixtures-with-templates/.env.example
+++ b/examples/filefixtures-with-templates/.env.example
@@ -9,5 +9,9 @@ MOCKSTACK__STRATEGY = filefixtures
 # and other hybrid strategies utilizing templates.
 MOCKSTACK__TEMPLATES_DIR = "./templates/"
 
+# When using filefixtures strategy, controls whether to enable
+# using templates for POST requests or go directly to simulate a create.
+FILEFIXTURES_ENABLE_TEMPLATES_FOR_POST = false
+
 # OpenTelemetry settings
 MOCKSTACK__OPENTELEMETRY__ENABLED = false

--- a/examples/filefixtures-with-templates/README.md
+++ b/examples/filefixtures-with-templates/README.md
@@ -14,3 +14,4 @@ We have a few example templates showcasing some of the capabilities of template-
 * Another template shows the naming convention for templates that depend on an identifier embedded in the request URL, e.g. `GET
     /someservice/api/v1/item/ae420979-33f3-4c99-bc42-9d7cdee5259e` would get routed to the template file `someservice-api-v1-item.ae420979-33f3-4c99-bc42-9d7cdee5259e.j2`.
 * Multiple identifiers in the path are also supported and would appear in filenames separated by dots, according to the order in which they appear in the URL.
+* A configuration value in controllable via `.env` / environment variables lets you also decide whether to allow using templates for POST requests or try to simulate a createion. When templates are allowed, mockstaack will first try to find a suitable template for the request based on the URL, and if it fails will fallback to the create simulation behavior.

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -1,0 +1,11 @@
+# LLMs
+
+**mockstack** can be a great tool for the development of LLM-based flows.
+
+A lot of current applications involve a sort of DAG of API calls to LLM APIs and various "tool" APIs, sometimes serially, sometimes in parallel, and sometimes in a "iterative" fashion (e.g. see [Agents](https://langchain-ai.github.io/langgraph/agents/overview/) documentation on LangGraph website).
+
+you can mock any of these parts out to accelerate development, debugging and integration testing of such workflows.
+
+Mocking out the LLMs themselves can be a particularly effective method to make sure no costs are incurred in early stages of development and in debugging scenarios that don't critically rely on the semantic content of the responses.
+
+This example shows a few possible scenarios involving mockstack and (mostly LangChain-based) LLM workflows.

--- a/examples/llm/mockstack-langchain-example.ipynb
+++ b/examples/llm/mockstack-langchain-example.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LLMs + mockstack\n",
+    "\n",
+    "A few simple examples for using `mockstack` to mock various components in typical LLM-driven use cases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install langchain dependencies with the following or using `uv` depending on your venv setup:\n",
+    "\n",
+    "#!pip install -q langchain langchain-openai\n",
+    "# or:\n",
+    "#!uv pip install langchain langchain-openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example #1: Template-based mocking (`filefixtures` strategy)\n",
+    "\n",
+    "Here we simply use the **filefixtures** strategy to route requesets coming in for a certain URL to a template file with the appropriate name.\n",
+    "\n",
+    "For the below example you'll want to make sure:\n",
+    "\n",
+    "- mockstack is running at http://localhost:8000 which are the default settings\n",
+    "- `MOCKSTACK__TEMPLATES_DIR` is pointing to a valid directory with a template file called `openai-v1-chat-completions.j2`. See the [included file](./templates/openai-v1-chat-completions.j2) with same name in the ./templates sub-directory of this example for a a template with a valid response based on [OpenAI API reference](https://platform.openai.com/docs/api-reference/chat/create).\n",
+    "- the `MOCKSTACK__FILEFIXTURES_ENABLE_TEMPLATES_FOR_POST` flag is set to true (which it should be by default)\n",
+    "\n",
+    "\n",
+    "If everything is setup correctly, you should get back the mocked response in the correct format from the template and the below assert should pass."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_openai import ChatOpenAI\n",
+    "\n",
+    "\n",
+    "llm = ChatOpenAI(\n",
+    "    model=\"gpt-4o\",\n",
+    "    temperature=0,\n",
+    "    max_tokens=None,\n",
+    "    timeout=None,\n",
+    "    max_retries=2,\n",
+    "    base_url=\"http://localhost:8000/openai/v1\",\n",
+    "    api_key=\"SOME_STRING_THAT_DOES_NOT_MATTER\",\n",
+    ")\n",
+    "\n",
+    "messages = [\n",
+    "    (\n",
+    "        \"system\",\n",
+    "        \"You are a helpful assistant that translates English to French. Translate the user sentence.\",\n",
+    "    ),\n",
+    "    (\"human\", \"I love programming.\"),\n",
+    "]\n",
+    "ai_msg = llm.invoke(messages)\n",
+    "\n",
+    "assert ai_msg.content == \"Hello! How can I assist you today?\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example #2: `llm` strategy\n",
+    "\n",
+    "** COMING SOON **"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example #3: mocking out a tool call\n",
+    "\n",
+    "** COMING SOON **"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/llm/templates/openai-v1-chat-completions.j2
+++ b/examples/llm/templates/openai-v1-chat-completions.j2
@@ -1,0 +1,35 @@
+ {
+   "id": "chatcmpl-B9MBs8CjcvOU2jLn4n570S5qMJKcT",
+   "object": "chat.completion",
+   "created": 1741569952,
+   "model": "gpt-4.1-2025-04-14",
+   "choices": [
+     {
+       "index": 0,
+       "message": {
+         "role": "assistant",
+         "content": "Hello! How can I assist you today?",
+         "refusal": null,
+         "annotations": []
+       },
+       "logprobs": null,
+       "finish_reason": "stop"
+     }
+   ],
+   "usage": {
+     "prompt_tokens": 19,
+     "completion_tokens": 10,
+     "total_tokens": 29,
+     "prompt_tokens_details": {
+       "cached_tokens": 0,
+       "audio_tokens": 0
+     },
+     "completion_tokens_details": {
+       "reasoning_tokens": 0,
+       "audio_tokens": 0,
+       "accepted_prediction_tokens": 0,
+       "rejected_prediction_tokens": 0
+     }
+   },
+   "service_tier": "default"
+ }

--- a/mockstack/config.py
+++ b/mockstack/config.py
@@ -61,6 +61,13 @@ class Settings(BaseSettings):
     # base directory for templates used by strategies
     templates_dir: DirectoryPath | None = None  # type: ignore[assignment]
 
+    # whether to enable templates for POST requests.
+    # By default, templates are not used for POSTs, and instead we try to
+    # simulate a create (or search) operation. If turned on, we will first
+    # try to materialize a template for the response, and if that fails
+    # with a 404, we will then try to simulate creation of the resource.
+    filefixtures_enable_templates_for_post: CliImplicitFlag[bool] = True
+
     # rules filename for proxyrules strategy
     proxyrules_rules_filename: FilePath | None = None  # type: ignore[assignment]
 

--- a/mockstack/tests/conftest.py
+++ b/mockstack/tests/conftest.py
@@ -46,6 +46,7 @@ def settings(templates_dir, proxyrules_rules_filename):
     return Settings(
         strategy="proxyrules",
         templates_dir=templates_dir,
+        filefixtures_enable_templates_for_post=False,
         proxyrules_rules_filename=proxyrules_rules_filename,
         proxyrules_redirect_via=ProxyRulesRedirectVia.HTTP_TEMPORARY_REDIRECT,
         proxyrules_simulate_create_on_missing=False,
@@ -59,6 +60,7 @@ def settings_reverse_proxy(templates_dir, proxyrules_rules_filename):
     return Settings(
         strategy="proxyrules",
         templates_dir=templates_dir,
+        filefixtures_enable_templates_for_post=False,
         proxyrules_rules_filename=proxyrules_rules_filename,
         proxyrules_redirect_via=ProxyRulesRedirectVia.REVERSE_PROXY,
         opentelemetry=OpenTelemetrySettings(enabled=False),
@@ -71,5 +73,6 @@ def settings_filefixtures(templates_dir):
     return Settings(
         strategy="filefixtures",
         templates_dir=templates_dir,
+        filefixtures_enable_templates_for_post=False,
         opentelemetry=OpenTelemetrySettings(enabled=False),
     )


### PR DESCRIPTION
- add support for using templates for POST requests, controlled by a config value defaulting to True
- update unit-tests