### PR TITLE
include URL fragments in proxy URLs

### DIFF
--- a/mockstack/rules.py
+++ b/mockstack/rules.py
@@ -4,6 +4,7 @@ import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Self
+from urllib.parse import quote
 
 from fastapi import Request
 
@@ -75,7 +76,11 @@ class Rule:
 
     def apply(self, request: Request) -> RuleResult:
         """Apply the rule to the request."""
-        path = request.url.path
+        path = f"{request.url.path}"
+        if request.url.fragment:
+            # If a URL fragment component is present, we URL encode it and include it in the path to proxy.
+            path += quote("#") + request.url.fragment
+
         result = self._url_for(path)
 
         # Check if the replacement is a file template

--- a/mockstack/tests/strategies/test_proxyrules.py
+++ b/mockstack/tests/strategies/test_proxyrules.py
@@ -7,7 +7,7 @@ import httpx
 import pytest
 from fastapi import Request, status
 from fastapi.responses import RedirectResponse
-from starlette.datastructures import Headers
+from starlette.datastructures import Headers, URL
 
 from mockstack.constants import ProxyRulesRedirectVia
 from mockstack.strategies.proxyrules import (
@@ -77,6 +77,27 @@ async def test_proxy_rules_strategy_apply(settings, span):
     response = await strategy.apply(request)
     assert isinstance(response, RedirectResponse)
     assert response.headers["location"] == "/projects/123"
+
+
+@pytest.mark.asyncio
+async def test_proxy_rules_strategy_apply_with_fragment(settings, span):
+    """Test applying a rule to a request with URL fragment."""
+    strategy = ProxyRulesStrategy(settings)
+    request = Request(
+        scope={
+            "type": "http",
+            "method": "GET",
+            "path": "/api/v1/projects/123",
+            "query_string": b"",
+            "headers": [],
+        }
+    )
+    # Set URL with fragment (fragments are client-side only in HTTP, but we test the logic)
+    request._url = URL("http://testserver/api/v1/projects/123#section")
+    request.state.span = span
+    response = await strategy.apply(request)
+    assert isinstance(response, RedirectResponse)
+    assert response.headers["location"] == "/projects/123%23section"
 
 
 @pytest.mark.asyncio

--- a/mockstack/tests/test_rules.py
+++ b/mockstack/tests/test_rules.py
@@ -2,6 +2,7 @@
 
 import pytest
 from fastapi import Request
+from starlette.datastructures import URL
 
 from mockstack.rules import Rule, TemplateRuleResult, URLRuleResult
 
@@ -79,34 +80,63 @@ def test_rule_matches_with_method(pattern, path, method, expected):
 
 
 @pytest.mark.parametrize(
-    "pattern,replacement,path,expected_url",
+    "pattern,replacement,path,fragment,expected_url",
     [
         (
             r"/api/v1/projects/(\d+)",
             r"/projects/\1",
             "/api/v1/projects/123",
+            None,
             "/projects/123",
         ),
         (
             r"/api/v1/users/([^/]+)",
             r"/users/\1",
             "/api/v1/users/john",
+            None,
             "/users/john",
+        ),
+        (
+            r"/api/v1/projects/(\d+)",
+            r"/projects/\1",
+            "/api/v1/projects/123",
+            "section",
+            "/projects/123%23section",
+        ),
+        (
+            r"/api/v1/users/([^/]+)",
+            r"/users/\1",
+            "/api/v1/users/john",
+            "profile",
+            "/users/john%23profile",
+        ),
+        (
+            r"/api/v1/projects/(\d+)",
+            r"/projects/\1",
+            "/api/v1/projects/456",
+            "top",
+            "/projects/456%23top",
         ),
     ],
 )
-def test_rule_apply(pattern, replacement, path, expected_url):
+def test_rule_apply(pattern, replacement, path, fragment, expected_url):
     """Test the rule application logic."""
     rule = Rule(pattern=pattern, replacement=replacement)
-    request = Request(
-        scope={
-            "type": "http",
-            "method": "GET",
-            "path": path,
-            "query_string": b"",
-            "headers": [],
-        }
-    )
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "query_string": b"",
+        "headers": [],
+    }
+    request = Request(scope=scope)
+
+    # If fragment is specified, we need to manually set the URL with the fragment
+    # since fragments are not part of standard HTTP requests (they're client-side)
+    if fragment:
+        url_with_fragment = f"http://testserver{path}#{fragment}"
+        request._url = URL(url_with_fragment)
+
     result = rule.apply(request)
     assert isinstance(result, URLRuleResult)
     assert result.get_result_type() == "url"


### PR DESCRIPTION
- Include URL Fragments ("#foo") when those are sent to the server as part of handling proxy rules