### PR TITLE
Fix uvx mockstack: replace removed @app.route with @app.api_route

### DIFF
--- a/mockstack/routers/catchall.py
+++ b/mockstack/routers/catchall.py
@@ -8,7 +8,9 @@ from mockstack.config import Settings
 def catchall_router_provider(app: FastAPI, settings: Settings) -> None:
     """Create the catch-all routes for the mockstack app."""
 
-    @app.route("/{full_path:path}", methods=["GET", "PATCH", "POST", "PUT", "DELETE"])
+    @app.api_route(
+        "/{full_path:path}", methods=["GET", "PATCH", "POST", "PUT", "DELETE"]
+    )
     async def catch_all(request: Request):
         """Catch all requests and delegate to the strategy."""
         return await app.state.strategy.apply(request)


### PR DESCRIPTION
## Summary

`uvx mockstack` has been crashing on startup with:

```
AttributeError: 'FastAPI' object has no attribute 'route'. Did you mean: 'router'?
```

**Root cause:** Starlette 1.0 dropped the Flask-style `@app.route` decorator that FastAPI inherited. We were never using FastAPI's documented public API — `@app.route` was a Starlette implementation detail. With `pyproject.toml` declaring only a lower bound (`fastapi[standard]>=0.115.12`), `uvx` resolves the latest matching versions from PyPI (currently fastapi 0.136.1 / starlette 1.0.0) rather than the older versions pinned in `uv.lock`. The lock file only governs local development (`uv sync`); it is not shipped in the wheel uploaded to PyPI.

**Fix:** Switch the catch-all route registration to FastAPI's native `@app.api_route(...)`, which has the same multi-method signature and is part of the FastAPI public API.

## Test plan

- [x] Existing `test_catchall_router_provider` passes against locked fastapi 0.116.1 / starlette 0.47.1
- [x] Manually verified `create_app()` succeeds and registers `/{full_path:path}` against fastapi 0.136.1 / starlette 1.0.0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)