### PR TITLE
ci: bump all GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,20 +23,16 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.python-version }}
         version: "latest"
     - name: Install ruff
-      uses: astral-sh/ruff-action@v3
+      uses: astral-sh/ruff-action@v4
       with:
         version: "latest"
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Install the project
       run: uv sync --all-extras --dev
     - name: Run ruff lint and formatting checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         version: "latest"
     - name: Install ruff
-      uses: astral-sh/ruff-action@v4
+      uses: astral-sh/ruff-action@v4.0.0
       with:
         version: "latest"
     - name: Install the project

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,16 +13,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Configure Git Credentials
         run: |
             git config --global user.name "${GITHUB_ACTOR}"
             git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - run: echo "cache_id=$(date --utc '+%V')" >> "${GITHUB_ENV}"
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,11 +10,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
     - name: Install pypa/build
@@ -23,7 +23,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: python-package-distributions
         path: dist/
@@ -42,7 +42,7 @@ jobs:
       id-token: write # IMPORTANT: mandatory for trusted publishing
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/
@@ -62,7 +62,7 @@ jobs:
       id-token: write # IMPORTANT: mandatory for sigstore
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/
@@ -98,7 +98,7 @@ jobs:
       id-token: write # IMPORTANT: mandatory for trusted publishing
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/smoke-test-pypi.yml
+++ b/.github/workflows/smoke-test-pypi.yml
@@ -23,10 +23,14 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: Install uv with Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: ${{ matrix.python-version }}
           version: "latest"
+          # We don't `actions/checkout` (the smoke test installs from PyPI),
+          # so silence setup-uv's empty-workdir + no-lock-to-cache warnings.
+          ignore-empty-workdir: true
+          enable-cache: false
 
       - name: Show resolved dependency versions
         run: |


### PR DESCRIPTION
## Summary

Bumps every GitHub Action across all four workflows to its current latest major version. Drivers:

- The smoke-test run on `main` (https://github.com/promptromp/mockstack/actions/runs/25226944841) surfaced a Node.js 20 deprecation warning from `astral-sh/setup-uv@v5`. GitHub will force Node 20 actions onto Node 24 starting 2026-06-02 and remove Node 20 from the runner image on 2026-09-16; bumping the action versions resolves this on all runners we use.
- Two additional smoke-test annotations (empty workdir, no cache files matched) are silenced by adding `ignore-empty-workdir: true` and `enable-cache: false` on the setup-uv step — the smoke test installs from PyPI without `actions/checkout`, so there is no workdir or lock file for setup-uv to operate on.

## Bumps

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-python` | v3 / v5 | v6 |
| `actions/cache` | v4 | v5 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `astral-sh/setup-uv` | v5 | **v8.1.0** (pinned full version) |
| `astral-sh/ruff-action` | v3 | v4 |

`pypa/gh-action-pypi-publish@release/v1` left as-is — that's the canonical moving release tag for that action.

`astral-sh/setup-uv` is pinned to a full version because Astral dropped floating major/minor tags from v8 onward as a supply-chain hardening (immutable releases). Dependabot will keep this current.

## Incidental cleanup

`ci.yml` had a redundant `actions/setup-python@v3` step running after `astral-sh/setup-uv@v5` (which already provisioned the matrix Python via its `python-version` input). Removed.

## Breaking-change review

Per upstream release notes, none of the bumps require workflow edits beyond what this PR makes:

- `actions/download-artifact` v5 changed path semantics only when downloading by `artifact-ids`; we download by `name` everywhere.
- `actions/upload-artifact` v7 added an opt-in `archive` input we don't use.
- `actions/setup-python` v6 added arch to the cache key (one-time cache miss, no YAML impact).
- `actions/checkout` v6 changed credential persistence internals only.
- `astral-sh/ruff-action` v4 only adds new optional inputs.

## Test plan

- [ ] Existing CI passes on this PR (exercises checkout v6, setup-uv v8.1.0, ruff-action v4 — i.e. all of `ci.yml`)
- [ ] After merge, manually trigger `Smoke Test (PyPI, latest deps)` via `workflow_dispatch` and confirm the three previous annotations no longer appear
- [ ] Publish workflows (`publish-to-pypi.yml`, `publish-docs.yml`) only run on tag / push to `main` and so will not exercise here; they'll be validated on the next release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)